### PR TITLE
Docs[README]: updated connector doc "connectors/sink-tencentcloud-scf…

### DIFF
--- a/connectors/sink-tencentcloud-scf/README.md
+++ b/connectors/sink-tencentcloud-scf/README.md
@@ -72,7 +72,7 @@ the `data` will be as payload to invoke function
 
 ### see logs in SCF console
 
-![log.png](https://github.com/linkall-labs/vance/blob/main/connectors/sink-tencentcloud-scf/scf-log.png)
+![log.png](https://github.com/linkall-labs/vance/blob/main/connectors/sink-tencentcloud-scf/scf-log.png?raw=true)
 
 ### clean resource
 


### PR DESCRIPTION
Fix for #136

**Changes:**
In vanus-connect/connectors/sink-tencentcloud-scf/README.md
Change image source https://github.com/linkall-labs/vance/blob/main/connectors/sink-tencentcloud-scf/scf-log.png to https://github.com/linkall-labs/vance/blob/main/connectors/sink-tencentcloud-scf/scf-log.png?raw=true.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/6383738/210155354-752d056f-7b47-4b87-a6d7-e057f330ef6f.png">
